### PR TITLE
QC coverage input

### DIFF
--- a/multiqc/modules/dragen/coverage_hist.py
+++ b/multiqc/modules/dragen/coverage_hist.py
@@ -139,6 +139,6 @@ def parse_wgs_fine_hist(f):
         data[depth] = cnt
         cum_data[depth] = cum_pct
 
-    m = re.search(r"(.*).wgs_fine_hist_?(tumor|normal)?.csv", f["fn"])
+    m = re.search(r"(.*)_fine_hist_?(tumor|normal)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     return sample, {phenotype: (data, cum_data, depth_1pc)}

--- a/multiqc/modules/dragen/coverage_per_contig.py
+++ b/multiqc/modules/dragen/coverage_per_contig.py
@@ -166,6 +166,6 @@ def parse_wgs_contig_mean_cov(f):
         )
     )
 
-    m = re.search(r"(.*).wgs_contig_mean_cov_?(tumor|normal)?.csv", f["fn"])
+    m = re.search(r"(.*)_contig_mean_cov?(tumor|normal)?.csv", f["fn"])
     sample, phenotype = m.group(1), m.group(2)
     return sample, {phenotype: [main_contig_perchrom_data, other_contig_perchrom_data]}


### PR DESCRIPTION
- Update contig_mean and fine_hist scripts in Dragen modules to allow input of qc-coverage-metrics files as well as wgs and target_bed to improve flexibility of scripts 
